### PR TITLE
Scroll to top

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,7 @@ $ npm install --save-dev webpack@4.19.1 webpack-cli@3.1.1 webpack-dev-server@3.1
 Also,
 1. Install and configure `file-loader` and `url-loader` to the `Webpack` framework in order to compile `url()` methods in css files.
 2. Implement images using `background: url()` in the css files.
+
+### dev notes
+Scroll to top solution to try:
+https://github.com/ReactTraining/react-router/issues/2019

--- a/README.md
+++ b/README.md
@@ -52,3 +52,5 @@ Add pivital tracker links to projects
 * Playdate: https://www.pivotaltracker.com/n/projects/2370835
 * Gnosis: https://www.pivotaltracker.com/n/projects/2384164
 * Kibbles 'n Bites: https://www.pivotaltracker.com/n/projects/2360231
+
+Add `enzyme` to list of technologies for unit testing js

--- a/README.md
+++ b/README.md
@@ -47,3 +47,8 @@ Also,
 ### dev notes
 Scroll to top solution to try:
 https://github.com/ReactTraining/react-router/issues/2019
+
+Add pivital tracker links to projects
+* Playdate: https://www.pivotaltracker.com/n/projects/2370835
+* Gnosis: https://www.pivotaltracker.com/n/projects/2384164
+* Kibbles 'n Bites: https://www.pivotaltracker.com/n/projects/2360231

--- a/README.md
+++ b/README.md
@@ -54,3 +54,6 @@ Add pivital tracker links to projects
 * Kibbles 'n Bites: https://www.pivotaltracker.com/n/projects/2360231
 
 Add `enzyme` to list of technologies for unit testing js
+
+Option to add an effect to each navlink in the navbar when the page is selected
+https://reacttraining.com/react-router/web/api/NavLink/isactive-func

--- a/src/components/CurriculumVitae.jsx
+++ b/src/components/CurriculumVitae.jsx
@@ -81,7 +81,7 @@ class CurriculumVitae extends Component {
         </div>
         <div className="px-1/5">{experienceList}</div>
       </div> */
-      <div class="component">
+      <div className="component">
         <p>Coming soon.  For more information about education, work experience, and publications, please visit my <a href="https://www.linkedin.com/in/maxaubain/">Linkedin profile</a>.</p>
       </div>
     );

--- a/src/components/DeveloperProjects.jsx
+++ b/src/components/DeveloperProjects.jsx
@@ -8,16 +8,16 @@ categories: Full Stack, Front End, Mobile, and Exercises.  */
 const DeveloperProjects = () => {
   return (
     <>
-      <div class="section-title">Full Stack Applications</div>
+      <div className="section-title">Full Stack Applications</div>
       <Projects path={"./src/data/projectsFullStack.json"} />
 
       <div className="section-title">Front End Applications</div>
       <Projects path={"./src/data/projectsFrontEnd.json"} />
 
-      <div class="section-title">Mobile Applications</div>
+      <div className="section-title">Mobile Applications</div>
       <Projects path={"./src/data/projectsMobile.json"} />
 
-      <div class="section-title">Coding Exercises</div>
+      <div className="section-title">Coding Exercises</div>
       <Projects path={"./src/data/projectsExercises.json"} />
     </>
   );

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,20 +1,18 @@
 import React, { Component } from "react";
 import { NavLink } from "react-router-dom";
 
-// NavBar component contains navlinks to content components.
-class NavBar extends Component {
   /*  Option for later: implement for underline effect under navlinks
   let currentLocation = window.location.pathname;
   console.log("current location", currentLocation) */
 
+// NavBar component contains navlinks to content components.
+class NavBar extends Component {
   constructor() {
     super();
     this.handleScroll = this.handleScroll.bind(this);
     this.state = { navbarState: "navbar" };
   }
 
-  /*  Adds/removes event listener that triggers on vertical
-  scroll anywhere on the page */
   componentDidMount() {
     window.addEventListener("scroll", this.handleScroll);
   }
@@ -23,7 +21,7 @@ class NavBar extends Component {
     window.removeEventListener("scroll", this.handleScroll);
   }
 
-  /* Checks absolute vertical scroll location and adds/removes className 
+  /* Checks vertical scroll location and adds/removes className 
   label to implement navbar shadow greater than 10 px scroll distance. */
   handleScroll(event) {
     let scrollLocation = document.documentElement.scrollTop;
@@ -34,19 +32,25 @@ class NavBar extends Component {
     }
   }
 
+  /* Sets view to top of page when navlink is clicked, otherwise
+  navlink keeps same vertical scroll location from previous view location */
+  resetView() {
+    window.scrollTo(0, 0);
+  }
+
   render() {
     return (
       <div id="navbar" className={this.state.navbarState}>
-        <NavLink className="navlink" to="/">
+        <NavLink className="navlink" to="/" onClick={this.resetView}>
           Profile
         </NavLink>
-        <NavLink className="navlink" to="WebDevelopment">
+        <NavLink className="navlink" to="WebDevelopment" onClick={this.resetView}>
           Web Development
         </NavLink>
-        <NavLink className="navlink" to="CurriculumVitae">
+        <NavLink className="navlink" to="CurriculumVitae" onClick={this.resetView}>
           Curriculum Vitae
         </NavLink>
-        <NavLink className="navlink" to="TravelBlog">
+        <NavLink className="navlink" to="TravelBlog" onClick={this.resetView}>
           Travel Blog
         </NavLink>
       </div>

--- a/src/components/Project.jsx
+++ b/src/components/Project.jsx
@@ -10,7 +10,7 @@ class Project extends Component {
 
   render() {
     const description_full = this.props.project.description_full.map(p => {
-      return <p>{p}</p>;
+      return <p key={p}>{p}</p>;
     });
 
     /* menuActivate() enables the showing/hiding of the 'project-details' 

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -1,6 +1,6 @@
 /* Global parameters and imports */
 html {
-  scroll-behavior: smooth;
+  /* scroll-behavior: smooth; */
 }
 
 body {

--- a/src/index.js
+++ b/src/index.js
@@ -50,9 +50,7 @@ WebFont.load({
 
 // Renders the App component in the virtual ReactDOM
 ReactDOM.render(
-  /* forceRefresh={true} is a quick fix so that when a NavLink is 
-  used, the page view starts at the top so all content is visible. */
-  <BrowserRouter forceRefresh={true}>
+  <BrowserRouter>
     <App />
   </BrowserRouter>,
   document.getElementById("app")

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,9 @@ WebFont.load({
 
 // Renders the App component in the virtual ReactDOM
 ReactDOM.render(
-  <BrowserRouter>
+  /* forceRefresh={true} is a quick fix so that when a NavLink is 
+  used, the page view starts at the top so all content is visible. */
+  <BrowserRouter forceRefresh={true}>
     <App />
   </BrowserRouter>,
   document.getElementById("app")


### PR DESCRIPTION
Problem: In a 'one page' website using React and React Router, the state of the vertical scroll location remains when switching between components using NavLink.

Solution: Setting an onClick event when the NavLink is used to set the window location to (0,0) resets the view in an intuitive way.

Misc. bug fixes:
1. Assigned key prop to full_description in Project.
2. Fixed 'class' to 'className' tag params.
3. Commented out scroll-behavior: smooth.
